### PR TITLE
Add Spotless Maven support via JSR-223

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,45 @@ spotless {
 }
 ```
 
-Put the Spotless module on the classpath where your build imports `PrinceOfSpaceStep` — for example `buildSrc` / `implementation`, or `buildscript { dependencies { classpath(...) } }` depending on your Gradle layout. Use `io.github.agustafson.princeofspace:prince-of-space-spotless:2.1.2` (pin to the version on Maven Central). Maven: add the same coordinate as a dependency of `spotless-maven-plugin`, then use `PrinceOfSpaceStep.create(...)` in the plugin configuration.
+Put the Spotless module on the classpath where your build imports `PrinceOfSpaceStep` — for example `buildSrc` / `implementation`, or `buildscript { dependencies { classpath(...) } }` depending on your Gradle layout. Use `io.github.agustafson.princeofspace:prince-of-space-spotless:2.1.2` (pin to the version on Maven Central). Maven users cannot call `PrinceOfSpaceStep.create(...)` — `spotless-maven-plugin` is configured in XML and has no extension point for third-party steps. Use the JSR-223 recipe below instead.
+
+#### Spotless (Maven)
+
+`spotless-maven-plugin`'s only generic step is `<jsr223>`. Run prince-of-space from a Groovy script, with `prince-of-space-core` and a Groovy JSR-223 engine on the plugin classpath:
+
+```xml
+<plugin>
+  <groupId>com.diffplug.spotless</groupId>
+  <artifactId>spotless-maven-plugin</artifactId>
+  <version>${spotless.maven.version}</version>
+  <dependencies>
+    <!-- prince-of-space-core on the plugin classloader (the script's thread context classloader) -->
+    <dependency>
+      <groupId>io.github.agustafson.princeofspace</groupId>
+      <artifactId>prince-of-space-core</artifactId>
+      <version>2.1.2</version>
+    </dependency>
+  </dependencies>
+  <configuration>
+    <java>
+      <jsr223>
+        <name>prince-of-space</name>
+        <!-- Groovy 4 (Groovy 3's bundled ASM rejects JDK 21+ class files);
+             spotless provisions this engine into the classloader ScriptEngineManager searches -->
+        <dependency>org.apache.groovy:groovy-jsr223:4.0.27</dependency>
+        <engine>groovy</engine>
+        <!-- Reflection via the thread context classloader: spotless's script classloader
+             exposes only com.diffplug.spotless.* and org.slf4j.*, not io.princeofspace.* -->
+        <script>def cl = Thread.currentThread().contextClassLoader; def fc = cl.loadClass('io.princeofspace.model.FormatterConfig'); cl.loadClass('io.princeofspace.Formatter').getDeclaredConstructor(fc).newInstance(fc.getMethod('defaults').invoke(null)).format(source)</script>
+      </jsr223>
+    </java>
+  </configuration>
+</plugin>
+```
+
+**Why the script looks like this:** `io.princeofspace.*` must be loaded by reflection via the thread context classloader because spotless's `FeatureClassLoader` only delegates `com.diffplug.spotless.*` and `org.slf4j.*` to the script — direct class references would fail at runtime. Groovy 4 is required because Groovy 3's bundled ASM rejects JDK 21+ class files. This is a working but spotless-internals-coupled workaround; revisit on major spotless version upgrades.
+
+To change formatting options, build a non-default `FormatterConfig` in the script (the `source` variable holds the unformatted code; the script's return value is the formatted code).
 
 ### IntelliJ Plugin
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,29 @@ Put the Spotless module on the classpath where your build imports `PrinceOfSpace
 
 **Why the script looks like this:** `io.princeofspace.*` must be loaded by reflection via the thread context classloader because spotless's `FeatureClassLoader` only delegates `com.diffplug.spotless.*` and `org.slf4j.*` to the script — direct class references would fail at runtime. Groovy 4 is required because Groovy 3's bundled ASM rejects JDK 21+ class files. This is a working but spotless-internals-coupled workaround; revisit on major spotless version upgrades.
 
-To change formatting options, build a non-default `FormatterConfig` in the script (the `source` variable holds the unformatted code; the script's return value is the formatted code).
+**Tuning the knobs.** The `source` variable holds the unformatted code; the script's return value is the formatted code. To override defaults, build a `FormatterConfig` via its builder. Because the script can only reach `io.princeofspace.*` reflectively, static calls (`builder()`, `JavaLanguageLevel.of`) and enum constants go through reflection, while the builder's instance setters dispatch dynamically in Groovy:
+
+```xml
+<script>
+def cl = Thread.currentThread().contextClassLoader
+def Cfg = cl.loadClass('io.princeofspace.model.FormatterConfig')
+def IndentStyle = cl.loadClass('io.princeofspace.model.IndentStyle')
+def WrapStyle = cl.loadClass('io.princeofspace.model.WrapStyle')
+def JLL = cl.loadClass('io.princeofspace.model.JavaLanguageLevel')
+def b = Cfg.getMethod('builder').invoke(null)
+b.indentStyle(Enum.valueOf(IndentStyle, 'SPACES'))
+b.indentSize(2)
+b.lineLength(100)
+b.wrapStyle(Enum.valueOf(WrapStyle, 'BALANCED'))
+b.closingParenOnNewLine(true)
+b.trailingCommas(false)
+b.javaLanguageLevel(JLL.getMethod('of', int.class).invoke(null, 21))
+def cfg = b.build()
+cl.loadClass('io.princeofspace.Formatter').getConstructor(Cfg).newInstance(cfg).format(source)
+</script>
+```
+
+The seven knobs are `indentStyle` (`SPACES`/`TABS`), `indentSize`, `lineLength`, `wrapStyle` (`WIDE`/`NARROW`/`BALANCED`), `closingParenOnNewLine`, `trailingCommas`, and `javaLanguageLevel` (`JavaLanguageLevel.of(n)`).
 
 ### IntelliJ Plugin
 

--- a/docs/formatting-rules.md
+++ b/docs/formatting-rules.md
@@ -496,7 +496,7 @@ enum Planet {
 
 ### Import Organisation
 
-**Delegated to Spotless.** The Prince of Space formatter does not handle import sorting, grouping, or removal. This is Spotless's responsibility and can be configured independently.
+**Delegated to Spotless.** The Prince of Space formatter does not handle import sorting, grouping, or removal. This is Spotless's responsibility and can be configured independently. For Maven, use the `spotless-maven-plugin` `<jsr223>` recipe in the README.
 
 ---
 

--- a/docs/technical-decision-register.md
+++ b/docs/technical-decision-register.md
@@ -249,3 +249,11 @@ Use it as the primary source of *why* design choices exist.
 - **Rationale:** Local development uses a SNAPSHOT `version=` line; showing that in Quick Start misleads copy-paste integrators. Separating “latest artifact on Central” from “next patch line under development” keeps README honest without coupling Nyx inference to docs.
 - **Consequences:** Release housekeeping updates both properties; `.github/workflows/sync-readme-versions.yml` continues to trigger on `gradle.properties` edits.
 - **Related docs:** `README.md`, `RELEASING.md`, `docs/benchmarks.md`, `build.gradle.kts` (`syncReadmeVersions`)
+
+### TDR-028: Maven Spotless support is delivered via a JSR-223 reflection recipe, not a native step
+- **Date:** 2026-06-30
+- **Status:** Accepted
+- **Decision:** Document and e2e-test the supported path: `spotless-maven-plugin`'s generic `<jsr223>` step. Two non-obvious constraints make it work: (a) the script must load `io.princeofspace.*` by reflection via the thread context classloader, because spotless's `FeatureClassLoader` only delegates `com.diffplug.spotless.*` and `org.slf4j.*` to scripts; (b) Groovy 4.x is required (Groovy 3's bundled ASM rejects JDK 21 class files). Do not build a first-party Maven mojo (a README non-goal); a native `<princeOfSpace>` element would require an upstream change to `diffplug/spotless` and is not pursued.
+- **Rationale:** Users asked to use prince-of-space from `spotless-maven-plugin`. The Gradle plugin accepts any `FormatterStep` via `addStep(PrinceOfSpaceStep.create(...))`, but the Maven plugin is XML-configured with a closed set of built-in step elements and exposes no SPI/ServiceLoader for third-party `FormatterStepFactory` implementations.
+- **Consequences:** README's prior instruction to “use `PrinceOfSpaceStep.create(...)` in the plugin configuration” was incorrect and is replaced by the JSR-223 recipe. An end-to-end test (`PrinceOfSpaceMavenJsr223IT`, gated on `PRINCE_MAVEN_IT`) runs `mvn spotless:apply` to guard the recipe. The recipe is coupled to spotless `FeatureClassLoader` internals and may need revisiting on major spotless upgrades.
+- **Related docs:** `README.md`, `docs/formatting-rules.md`

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ javaparser = "3.28.0"
 jqwik = "1.9.3"
 jspecify = "1.0.0"
 junit = "6.0.3"
+maven-invoker = "3.3.0"
 maven-resolver = "1.9.22"
 mkdocs-build = "4.0.1"
 nullaway = "0.13.4"
@@ -39,6 +40,7 @@ junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+maven-invoker = { module = "org.apache.maven.shared:maven-invoker", version.ref = "maven-invoker" }
 maven-resolver-api = { module = "org.apache.maven.resolver:maven-resolver-api", version.ref = "maven-resolver" }
 nullaway = { module = "com.uber.nullaway:nullaway", version.ref = "nullaway" }
 palantir-java-format = { module = "com.palantir.javaformat:palantir-java-format", version.ref = "palantir-java-format" }

--- a/modules/spotless/build.gradle.kts
+++ b/modules/spotless/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     testRuntimeOnly(libs.junit.jupiter.engine)
     testRuntimeOnly(libs.junit.platform.launcher)
     testImplementation(libs.assertj.core)
+    testImplementation(libs.maven.invoker)
 }
 
 tasks.test {

--- a/modules/spotless/src/test/java/io/princeofspace/spotless/PrinceOfSpaceMavenJsr223IT.java
+++ b/modules/spotless/src/test/java/io/princeofspace/spotless/PrinceOfSpaceMavenJsr223IT.java
@@ -48,6 +48,29 @@ class PrinceOfSpaceMavenJsr223IT {
     }
 
     @Test
+    void java25MaxLanguageFeaturesFormatsAndIsIdempotent(@TempDir Path work) throws Exception {
+        assumeTrue("true".equals(System.getenv("PRINCE_MAVEN_IT")),
+                "set PRINCE_MAVEN_IT=true to run the Maven end-to-end test");
+
+        // Copy the java25 fixture project into a writable temp dir.
+        Path fixture = Path.of("src/test/resources/maven-it-java25");
+        try (Stream<Path> paths = Files.walk(fixture)) {
+            paths.forEach(src -> copy(src, work.resolve(fixture.relativize(src))));
+        }
+        Path sample = work.resolve("src/main/java/it/Java25Features.java");
+
+        // First apply: must reformat the file (mis-formatted `x=1` → `x = 1`).
+        runApply(work);
+        String formatted = Files.readString(sample);
+        assertThat(formatted).contains("int x = 1;");
+        assertThat(formatted).doesNotContain("int x=1;");
+
+        // Second apply: idempotent — file unchanged.
+        runApply(work);
+        assertThat(Files.readString(sample)).isEqualTo(formatted);
+    }
+
+    @Test
     void tunedKnobsFormatsWithTwoSpaceIndentAndIsIdempotent(@TempDir Path work) throws Exception {
         assumeTrue("true".equals(System.getenv("PRINCE_MAVEN_IT")),
                 "set PRINCE_MAVEN_IT=true to run the Maven end-to-end test");

--- a/modules/spotless/src/test/java/io/princeofspace/spotless/PrinceOfSpaceMavenJsr223IT.java
+++ b/modules/spotless/src/test/java/io/princeofspace/spotless/PrinceOfSpaceMavenJsr223IT.java
@@ -1,0 +1,80 @@
+package io.princeofspace.spotless;
+
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.DefaultInvoker;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.Invoker;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * End-to-end check that prince-of-space formats Java through spotless-maven-plugin's
+ * {@code <jsr223>} step. Gated on {@code PRINCE_MAVEN_IT=true} because it shells out to a
+ * real Maven and downloads spotless-maven-plugin + groovy from Maven Central.
+ */
+class PrinceOfSpaceMavenJsr223IT {
+
+    @Test
+    void mavenSpotlessApplyFormatsAndIsIdempotent(@TempDir Path work) throws Exception {
+        assumeTrue("true".equals(System.getenv("PRINCE_MAVEN_IT")),
+                "set PRINCE_MAVEN_IT=true to run the Maven end-to-end test");
+
+        // Copy the fixture project into a writable temp dir.
+        Path fixture = Path.of("src/test/resources/maven-it");
+        try (Stream<Path> paths = Files.walk(fixture)) {
+            paths.forEach(src -> copy(src, work.resolve(fixture.relativize(src))));
+        }
+        Path sample = work.resolve("src/main/java/it/Sample.java");
+
+        // First apply: must reformat the file.
+        runApply(work);
+        String formatted = Files.readString(sample);
+        assertThat(formatted).contains("int x = 1;");
+        assertThat(formatted).doesNotContain("int x=1;");
+
+        // Second apply: idempotent — file unchanged.
+        runApply(work);
+        assertThat(Files.readString(sample)).isEqualTo(formatted);
+    }
+
+    private static void runApply(Path projectDir) throws Exception {
+        InvocationRequest request = new DefaultInvocationRequest();
+        request.setPomFile(projectDir.resolve("pom.xml").toFile());
+        request.setGoals(singletonList("spotless:apply"));
+        request.setBatchMode(true);
+        Invoker invoker = new DefaultInvoker();
+        String mavenHome = System.getenv("MAVEN_HOME");
+        if (mavenHome != null) {
+            invoker.setMavenHome(new File(mavenHome));
+        }
+        InvocationResult result = invoker.execute(request);
+        if (result.getExecutionException() != null) {
+            throw result.getExecutionException();
+        }
+        assertThat(result.getExitCode()).as("mvn spotless:apply exit code").isZero();
+    }
+
+    private static void copy(Path src, Path dest) {
+        try {
+            if (Files.isDirectory(src)) {
+                Files.createDirectories(dest);
+            } else {
+                Files.createDirectories(dest.getParent());
+                Files.copy(src, dest);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/modules/spotless/src/test/java/io/princeofspace/spotless/PrinceOfSpaceMavenJsr223IT.java
+++ b/modules/spotless/src/test/java/io/princeofspace/spotless/PrinceOfSpaceMavenJsr223IT.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.stream.Stream;
 
 import static java.util.Collections.singletonList;

--- a/modules/spotless/src/test/java/io/princeofspace/spotless/PrinceOfSpaceMavenJsr223IT.java
+++ b/modules/spotless/src/test/java/io/princeofspace/spotless/PrinceOfSpaceMavenJsr223IT.java
@@ -47,6 +47,31 @@ class PrinceOfSpaceMavenJsr223IT {
         assertThat(Files.readString(sample)).isEqualTo(formatted);
     }
 
+    @Test
+    void tunedKnobsFormatsWithTwoSpaceIndentAndIsIdempotent(@TempDir Path work) throws Exception {
+        assumeTrue("true".equals(System.getenv("PRINCE_MAVEN_IT")),
+                "set PRINCE_MAVEN_IT=true to run the Maven end-to-end test");
+
+        // Copy the tuned fixture project into a writable temp dir.
+        Path fixture = Path.of("src/test/resources/maven-it-tuned");
+        try (Stream<Path> paths = Files.walk(fixture)) {
+            paths.forEach(src -> copy(src, work.resolve(fixture.relativize(src))));
+        }
+        Path sample = work.resolve("src/main/java/it/Sample.java");
+
+        // First apply: must reformat with 2-space indent (not the default 4).
+        // At 2-space indent the first class-body member (void m) is indented 2 spaces.
+        // At the default 4-space indent it would be indented 4 spaces.
+        runApply(work);
+        String formatted = Files.readString(sample);
+        assertThat(formatted).contains("  void m()");
+        assertThat(formatted).doesNotContain("    void m()");
+
+        // Second apply: idempotent — file unchanged.
+        runApply(work);
+        assertThat(Files.readString(sample)).isEqualTo(formatted);
+    }
+
     private static void runApply(Path projectDir) throws Exception {
         InvocationRequest request = new DefaultInvocationRequest();
         request.setPomFile(projectDir.resolve("pom.xml").toFile());

--- a/modules/spotless/src/test/resources/maven-it-java25/pom.xml
+++ b/modules/spotless/src/test/resources/maven-it-java25/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>it</groupId>
+  <artifactId>prince-maven-it-java25</artifactId>
+  <version>0.0.1</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.release>21</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <spotless.maven.version>2.44.5</spotless.maven.version>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless.maven.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>io.github.agustafson.princeofspace</groupId>
+            <artifactId>prince-of-space-core</artifactId>
+            <version>2.1.3-SNAPSHOT</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <java>
+            <jsr223>
+              <name>prince-of-space-java25</name>
+              <dependency>org.apache.groovy:groovy-jsr223:4.0.27</dependency>
+              <engine>groovy</engine>
+              <script>
+def cl = Thread.currentThread().contextClassLoader
+def Cfg = cl.loadClass('io.princeofspace.model.FormatterConfig')
+def JLL = cl.loadClass('io.princeofspace.model.JavaLanguageLevel')
+def b = Cfg.getMethod('builder').invoke(null)
+b.javaLanguageLevel(JLL.getMethod('of', int.class).invoke(null, 25))
+def cfg = b.build()
+cl.loadClass('io.princeofspace.Formatter').getConstructor(Cfg).newInstance(cfg).format(source)
+              </script>
+            </jsr223>
+          </java>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/modules/spotless/src/test/resources/maven-it-java25/src/main/java/it/Java25Features.java
+++ b/modules/spotless/src/test/resources/maven-it-java25/src/main/java/it/Java25Features.java
@@ -1,0 +1,100 @@
+package it;
+import java.util.*;import java.util.function.*;import java.util.stream.*;
+/** Deliberately mis-formatted file exercising Java 25 language features (NON-preview). */
+@SuppressWarnings({"unused","unchecked"})
+public class Java25Features{
+
+// ------- enhanced enum with abstract method per constant -------
+enum Planet{
+MERCURY(3.303e+23,2.4397e6){@Override public double gravity(){return G*mass/radius/radius;}},
+VENUS(4.869e+24,6.0518e6){@Override public double gravity(){return G*mass/radius/radius;}};
+private static final double G=6.673e-11;
+final double mass;final double radius;
+Planet(double mass,double radius){this.mass=mass;this.radius=radius;}
+public abstract double gravity();
+}
+
+// ------- sealed interface + permits + inner records -------
+sealed interface Shape permits Shape.Circle,Shape.Rect,Shape.Tri{
+double area();
+record Circle(double radius) implements Shape{@Override public double area(){return Math.PI*radius*radius;}}
+record Rect(double w,double h) implements Shape{@Override public double area(){return w*h;}}
+record Tri(double b,double h) implements Shape{@Override public double area(){return 0.5*b*h;}}
+}
+
+// ------- generic record -------
+record Pair<A,B>(A first,B second){}
+
+// ------- nested generics field -------
+Map<String,List<? extends Number>> table=new HashMap<>();
+
+// ------- main feature showcase method -------
+void features(){
+// var + ArrayList
+var list=new ArrayList<String>();list.add("hello");list.add("world");
+
+// deliberately mis-spaced assignment to confirm reformatting
+int x=1;System.out.println(x);
+
+// lambda + method reference + bounded wildcard
+Comparator<String> cmp=(a,b)->Integer.compare(a.length(),b.length());
+list.sort(String::compareTo);
+
+// text block
+String json="""
+{"name":"test","value":42}
+""";
+
+// pattern-matching instanceof
+Object obj="hello world";
+if(obj instanceof String s){System.out.println(s.toUpperCase());}
+
+// switch expression (arrow form)
+int day=3;
+String dayName=switch(day){case 1->"Mon";case 2->"Tue";case 3->"Wed";default->"Other";};
+
+// record patterns in switch + when guards
+Shape shape=new Shape.Circle(5.0);
+String sizeLabel=switch(shape){
+case Shape.Circle(var r) when r>100->"large circle";
+case Shape.Circle(var r) when r>10->"medium circle";
+case Shape.Circle c->"small circle";
+case Shape.Rect(var w,var h) when w==h->"square:"+w;
+case Shape.Rect r->"rect:"+r.w()+"x"+r.h();
+case Shape.Tri(var b,var h)->"tri:"+b+"x"+h;
+};
+
+// switch expression with type patterns
+double area=switch(shape){
+case Shape.Circle(var r)->Math.PI*r*r;
+case Shape.Rect(var w,var h)->w*h;
+case Shape.Tri(var b,var h)->0.5*b*h;
+};
+
+// unnamed variable _ (Java 22, non-preview)
+try{int parsed=Integer.parseInt("not-a-number");}catch(NumberFormatException _){System.out.println("parse failed");}
+
+// stream with method refs
+var upper=list.stream().filter(s->s.length()>3).map(String::toUpperCase).collect(Collectors.toList());
+
+// bounded wildcards + stream
+List<? extends Number> nums=List.of(1,2,3);
+double sum=nums.stream().mapToDouble(Number::doubleValue).sum();
+
+// ternary expression
+String label=list.isEmpty()?"none":list.getFirst();
+
+// local record (Java 16+, non-preview)
+record TaggedValue(String tag,int value){String describe(){return tag+":"+value;}}
+var tv=new TaggedValue("score",42);
+System.out.println(tv.describe());
+}
+
+// ------- method using bounded wildcards and generics -------
+<T extends Comparable<T>> List<T> sorted(List<? extends T> input){
+return input.stream().map(x->x).sorted().collect(Collectors.toList());
+}
+
+// ------- functional interface field + lambda returning lambda -------
+Function<String,Function<String,String>> curried=prefix->suffix->prefix+":"+suffix;
+}

--- a/modules/spotless/src/test/resources/maven-it-tuned/pom.xml
+++ b/modules/spotless/src/test/resources/maven-it-tuned/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>it</groupId>
+  <artifactId>prince-maven-it-tuned</artifactId>
+  <version>0.0.1</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <spotless.maven.version>2.44.5</spotless.maven.version>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless.maven.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>io.github.agustafson.princeofspace</groupId>
+            <artifactId>prince-of-space-core</artifactId>
+            <version>2.1.3-SNAPSHOT</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <java>
+            <jsr223>
+              <name>prince-of-space-tuned</name>
+              <dependency>org.apache.groovy:groovy-jsr223:4.0.27</dependency>
+              <engine>groovy</engine>
+              <script>
+def cl = Thread.currentThread().contextClassLoader
+def Cfg = cl.loadClass('io.princeofspace.model.FormatterConfig')
+def IndentStyle = cl.loadClass('io.princeofspace.model.IndentStyle')
+def WrapStyle = cl.loadClass('io.princeofspace.model.WrapStyle')
+def JLL = cl.loadClass('io.princeofspace.model.JavaLanguageLevel')
+def b = Cfg.getMethod('builder').invoke(null)
+b.indentStyle(Enum.valueOf(IndentStyle, 'SPACES'))
+b.indentSize(2)
+b.lineLength(100)
+b.wrapStyle(Enum.valueOf(WrapStyle, 'BALANCED'))
+b.closingParenOnNewLine(true)
+b.trailingCommas(false)
+b.javaLanguageLevel(JLL.getMethod('of', int.class).invoke(null, 21))
+def cfg = b.build()
+cl.loadClass('io.princeofspace.Formatter').getConstructor(Cfg).newInstance(cfg).format(source)
+              </script>
+            </jsr223>
+          </java>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/modules/spotless/src/test/resources/maven-it-tuned/src/main/java/it/Sample.java
+++ b/modules/spotless/src/test/resources/maven-it-tuned/src/main/java/it/Sample.java
@@ -1,0 +1,2 @@
+package it;
+class Sample{void m(){if(true){int x=1;System.out.println(x);}}}

--- a/modules/spotless/src/test/resources/maven-it/pom.xml
+++ b/modules/spotless/src/test/resources/maven-it/pom.xml
@@ -22,11 +22,6 @@
         <version>${spotless.maven.version}</version>
         <dependencies>
           <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-jsr223</artifactId>
-            <version>3.0.9</version>
-          </dependency>
-          <dependency>
             <groupId>io.github.agustafson.princeofspace</groupId>
             <artifactId>prince-of-space-core</artifactId>
             <version>2.1.3-SNAPSHOT</version>
@@ -36,8 +31,9 @@
           <java>
             <jsr223>
               <name>prince-of-space</name>
+              <dependency>org.apache.groovy:groovy-jsr223:4.0.27</dependency>
               <engine>groovy</engine>
-              <script>new io.princeofspace.Formatter(io.princeofspace.model.FormatterConfig.defaults()).format(source)</script>
+              <script>def cl = Thread.currentThread().contextClassLoader; def fc = cl.loadClass('io.princeofspace.model.FormatterConfig'); cl.loadClass('io.princeofspace.Formatter').getDeclaredConstructor(fc).newInstance(fc.getMethod('defaults').invoke(null)).format(source)</script>
             </jsr223>
           </java>
         </configuration>

--- a/modules/spotless/src/test/resources/maven-it/pom.xml
+++ b/modules/spotless/src/test/resources/maven-it/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>it</groupId>
+  <artifactId>prince-maven-it</artifactId>
+  <version>0.0.1</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <spotless.maven.version>2.44.5</spotless.maven.version>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless.maven.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-jsr223</artifactId>
+            <version>3.0.9</version>
+          </dependency>
+          <dependency>
+            <groupId>io.github.agustafson.princeofspace</groupId>
+            <artifactId>prince-of-space-core</artifactId>
+            <version>2.1.3-SNAPSHOT</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <java>
+            <jsr223>
+              <name>prince-of-space</name>
+              <engine>groovy</engine>
+              <script>new io.princeofspace.Formatter(io.princeofspace.model.FormatterConfig.defaults()).format(source)</script>
+            </jsr223>
+          </java>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/modules/spotless/src/test/resources/maven-it/src/main/java/it/Sample.java
+++ b/modules/spotless/src/test/resources/maven-it/src/main/java/it/Sample.java
@@ -1,0 +1,2 @@
+package it;
+class Sample{void m(){int x=1;System.out.println(x);}}


### PR DESCRIPTION
## What

Makes prince-of-space usable from `spotless-maven-plugin`, and corrects a false README claim.

## Why

`spotless-maven-plugin` is XML-configured with a **closed step set and no SPI** for third-party `FormatterStepFactory` — the Gradle `addStep(PrinceOfSpaceStep.create(...))` path has no Maven equivalent. The prior README told Maven users to "use `PrinceOfSpaceStep.create(...)` in the plugin configuration", which is impossible. The only supported third-party mechanism is the plugin's generic `<jsr223>` step.

## How

A `<jsr223>` Groovy recipe calling `io.princeofspace.Formatter`. Three non-obvious constraints, all documented:

- **Reflection via the thread context classloader** — spotless's `FeatureClassLoader` exposes only `com.diffplug.spotless.*` and `org.slf4j.*` to scripts, so `io.princeofspace.*` cannot be referenced directly.
- **Groovy 4.x** — Groovy 3's bundled ASM rejects JDK 21+ class files.
- **Engine declared inside `<jsr223><dependency>`** — where spotless provisions the engine onto the classloader `ScriptEngineManager` searches.

## Verification

`PrinceOfSpaceMavenJsr223IT` runs real `mvn spotless:apply` (maven-invoker), gated behind `PRINCE_MAVEN_IT` so default build/CI is unaffected. Three cases, all asserting reformat **and** idempotency:

1. Defaults recipe.
2. Tuned knobs (`indentSize=2`, `lineLength=100`) via builder-through-reflection.
3. Java 25 max-language-features fixture (records, sealed types, record patterns, switch patterns + `when` guards, text blocks, `var`, unnamed variable, …). JavaParser 3.28.0 caps at `JAVA_25`.

No production code touched; `:spotless` JaCoCo gate unaffected. Clean `./gradlew build`.
