### PR TITLE
fix: stop cli:jar and cli:shadowJar from racing on the same output path

### DIFF
--- a/modules/cli/build.gradle.kts
+++ b/modules/cli/build.gradle.kts
@@ -51,6 +51,15 @@ tasks.check {
     dependsOn(tasks.jacocoTestCoverageVerification)
 }
 
+tasks.jar {
+    // Plain jar isn't published; keep its output filename off both the shadowJar's path and the
+    // "prince-of-space-cli-*.jar" glob the VS Code extension scans for (see formatter.ts), so the
+    // two jar tasks never race to write the same file and the IDE never picks up the unshaded jar.
+    // (Gradle flags the path collision as an implicit-dependency validation problem since it can
+    // otherwise publish/sign the wrong jar depending on task order.)
+    archiveBaseName.set("cli")
+}
+
 tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
     archiveBaseName.set("prince-of-space-cli")
     archiveClassifier.set("")


### PR DESCRIPTION
The release workflow failed at :cli:signMavenPublication because Gradle's
task validation detected an implicit dependency problem: both the plain
`jar` task and `shadowJar` wrote to build/libs/prince-of-space-cli-<version>.jar
(jar inherited the project's archivesName, and shadowJar set the same base
name with an empty classifier). Since only shadowJar was wired into the
publication, the two tasks could race and leave the unshaded jar published
or signed depending on execution order. Give the plain jar task its own
base name so it no longer collides with the published shaded jar.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VEfJQHn15uxNoEo6GZnLAQ