### PR TITLE
fix: sync README to v2.2.0 and make release push race-resistant

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -471,9 +471,26 @@ jobs:
             exit 0
           fi
           git commit -m "chore: update changelog, README coordinates, and set version to ${NEXT_SNAPSHOT} after v${RELEASE_VERSION}"
-          # Branch protection may forbid direct pushes to main. Do not fail the release if this
-          # housekeeping commit cannot be pushed; the next run can still use Nyx + tags safely.
-          if ! git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_REF_NAME}"; then
-            echo "::warning::Could not push ${NEXT_SNAPSHOT} bump commit (likely branch protection)."
+          # Another push to this branch (e.g. the Spring benchmark refresh job) can land between
+          # our checkout and this push, which rejects as non-fast-forward, not branch protection.
+          # Retry a few times with a rebase onto the latest branch tip before giving up. Branch
+          # protection can still legitimately reject every attempt; do not fail the release for
+          # that — the next release run can still use Nyx + tags safely.
+          PUSH_REMOTE="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          PUSHED=false
+          for attempt in 1 2 3 4 5; do
+            if git push "${PUSH_REMOTE}" "HEAD:${GITHUB_REF_NAME}"; then
+              PUSHED=true
+              break
+            fi
+            echo "Push attempt ${attempt} was rejected; fetching latest ${GITHUB_REF_NAME} and rebasing before retrying."
+            if ! git fetch "${PUSH_REMOTE}" "${GITHUB_REF_NAME}" || ! git rebase FETCH_HEAD; then
+              git rebase --abort 2>/dev/null || true
+              echo "::warning::Rebase failed while retrying the ${NEXT_SNAPSHOT} bump commit push; leaving it unpushed."
+              break
+            fi
+          done
+          if [[ "${PUSHED}" != "true" ]]; then
+            echo "::warning::Could not push ${NEXT_SNAPSHOT} bump commit (race with a concurrent push, or branch protection)."
             echo "::warning::Create this commit via PR manually, or allow GitHub Actions to bypass protection."
           fi

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Prince of Space takes its philosophy from Prettier and ktlint: strong, readable 
 
 ```kotlin
 dependencies {
-    implementation("io.github.agustafson.princeofspace:prince-of-space-core:2.1.2")
+    implementation("io.github.agustafson.princeofspace:prince-of-space-core:2.2.0")
 }
 ```
 
@@ -52,7 +52,7 @@ String formatted = formatter.format(sourceCode);
 <dependency>
     <groupId>io.github.agustafson.princeofspace</groupId>
     <artifactId>prince-of-space-core</artifactId>
-    <version>2.1.2</version>
+    <version>2.2.0</version>
 </dependency>
 ```
 
@@ -87,7 +87,7 @@ spotless {
 }
 ```
 
-Put the Spotless module on the classpath where your build imports `PrinceOfSpaceStep` — for example `buildSrc` / `implementation`, or `buildscript { dependencies { classpath(...) } }` depending on your Gradle layout. Use `io.github.agustafson.princeofspace:prince-of-space-spotless:2.1.2` (pin to the version on Maven Central).
+Put the Spotless module on the classpath where your build imports `PrinceOfSpaceStep` — for example `buildSrc` / `implementation`, or `buildscript { dependencies { classpath(...) } }` depending on your Gradle layout. Use `io.github.agustafson.princeofspace:prince-of-space-spotless:2.2.0` (pin to the version on Maven Central).
 
 ### Spotless (Maven)
 
@@ -109,7 +109,7 @@ Put the Spotless module on the classpath where your build imports `PrinceOfSpace
               <artifactItem>
                 <groupId>io.github.agustafson.princeofspace</groupId>
                 <artifactId>prince-of-space-cli</artifactId>
-                <version>2.1.2</version>
+                <version>2.2.0</version>
                 <destFileName>prince-of-space-cli.jar</destFileName>
               </artifactItem>
             </artifactItems>
@@ -284,10 +284,10 @@ Group ID: **`io.github.agustafson.princeofspace`**. Published versions appear on
 
 | Artifact | Coordinate | When to use |
 |----------|------------|-------------|
-| `prince-of-space-core` | `io.github.agustafson.princeofspace:prince-of-space-core:2.1.2` | Default — small footprint; JavaParser + SLF4J as normal transitives |
-| `prince-of-space-bundled` | `io.github.agustafson.princeofspace:prince-of-space-bundled:2.1.2` | Single fat JAR, dependencies relocated — no classpath clashes |
-| `prince-of-space-spotless` | `io.github.agustafson.princeofspace:prince-of-space-spotless:2.1.2` | Spotless `FormatterStep` (`PrinceOfSpaceStep`) |
-| `prince-of-space-cli` | `io.github.agustafson.princeofspace:prince-of-space-cli:2.1.2` | Self-contained CLI jar (`java -jar ... --stdin`); same artifact is also attached to [GitHub Releases](https://github.com/agustafson/prince-of-space/releases) |
+| `prince-of-space-core` | `io.github.agustafson.princeofspace:prince-of-space-core:2.2.0` | Default — small footprint; JavaParser + SLF4J as normal transitives |
+| `prince-of-space-bundled` | `io.github.agustafson.princeofspace:prince-of-space-bundled:2.2.0` | Single fat JAR, dependencies relocated — no classpath clashes |
+| `prince-of-space-spotless` | `io.github.agustafson.princeofspace:prince-of-space-spotless:2.2.0` | Spotless `FormatterStep` (`PrinceOfSpaceStep`) |
+| `prince-of-space-cli` | `io.github.agustafson.princeofspace:prince-of-space-cli:2.2.0` | Self-contained CLI jar (`java -jar ... --stdin`); same artifact is also attached to [GitHub Releases](https://github.com/agustafson/prince-of-space/releases) |
 
 ## Non-goals
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.configuration-cache=true
 
 group=io.github.agustafson.princeofspace
 # Last version published to Maven Central — README Quick Start / coordinate snippets track this (see syncReadmeVersions).
-readmeMavenCoordinatesVersion=2.1.2
+readmeMavenCoordinatesVersion=2.2.0
 # Default for local ./gradlew and non-release CI (next patch line after the last tag).
 # The release workflow bumps this to <next>-SNAPSHOT after each successful publish (one chore commit).
 # CI release inference ignores this — it uses Nyx against git tags + conventional commits.
-version=2.1.3-SNAPSHOT
+version=2.2.1-SNAPSHOT


### PR DESCRIPTION
v2.2.0 published successfully (tag, GitHub Release, Maven Central), but
the release workflow's housekeeping push (gradle.properties bump +
syncReadmeVersions) was rejected as non-fast-forward because the
readme-benchmark workflow committed to main in between, and the script
treated any push failure as benign branch-protection and gave up. README
and gradle.properties still pointed at 2.1.2 as a result.

Sync README/gradle.properties to 2.2.0 now, and have the release
workflow retry the housekeeping push with a rebase before falling back
to a warning, so a concurrent commit doesn't silently drop it.